### PR TITLE
修改 Markdown 解析代码以支持 sup 标签

### DIFF
--- a/site/_core/Marked.js
+++ b/site/_core/Marked.js
@@ -450,6 +450,7 @@ var inline = {
   escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
   autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
   url: noop,
+  sup: /^<sup>([\s\S]+?)<\/sup>/,
   tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
   link: /^!?\[(inside)\]\(href\)/,
   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
@@ -593,6 +594,13 @@ InlineLexer.prototype.output = function(src) {
       text = cap[1];
       href = text;
       out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
+      continue;
+    }
+
+    // sup
+    if (cap = this.rules.sup.exec(src)) {
+      src = src.substring(cap[0].length);
+      out.push(React.DOM.sup(null, this.output(cap[2] || cap[1])));
       continue;
     }
 


### PR DESCRIPTION
由于本站使用的 Markdown 解析器暂不支持在 Markdown 段落中直接使用 HTML 行内标签，导致无法正常使用脚注功能，因此添加对 sup 标签的支持
修改后可用的脚注方式如下：

```html
正文<sup>[\[1\]](#note1)</sup> blablabla……

<!-- 由于<a name="xxx"> 也无法放在 Markdown 段落中，这里使用全 HTML 段落来解析 -->
<ol>
<li><a name="note1"></a> 脚注 1</li>
</ol>
```

close #62