### PR TITLE
Tutorial-GraphQLClients.md fix

### DIFF
--- a/site/graphql-js/Tutorial-GraphQLClients.md
+++ b/site/graphql-js/Tutorial-GraphQLClients.md
@@ -8,7 +8,7 @@ next: /graphql-js/basic-types/
 
 由于 GraphQL API 拥有比 REST API 更多的下层结构，它也有更强大的客户端。譬如 [Relay](https://facebook.github.io/relay/)，它能自动操作批处理、缓存等等。但你并不需要一个复杂的客户端才能调用 GraphQL 服务器，在有了 `express-graphql` 的情况下，你可以向 GraphQL 服务器上的入口端点发送一个 HTTP POST 请求，其中将 GraphQL 查询作为 JSON 载荷的 `query` 字段，就能调用 GraphQL 服务器。
 
-假设我们运行了 [Express GraphQL 服务器](/graphql-js/running-an-express-graphql-server/) 的示例代码，GraphQL 服务运行于 http://localhost:4000/graphql，我们想要发送 GraphQL 查询 `{ hello }`。我们可以在命令行中使用 `curl` 来发送这一请求，将下面代码粘贴到终端中去：
+假设我们运行了 [Express GraphQL 服务器](/graphql-js/running-an-express-graphql-server/) 的示例代码，GraphQL 服务运行于 http://localhost:4000/graphql ，我们想要发送 GraphQL 查询 `{ hello }`。我们可以在命令行中使用 `curl` 来发送这一请求，将下面代码粘贴到终端中去：
 
 ```bash
 curl -X POST \
@@ -23,7 +23,7 @@ http://localhost:4000/graphql
 {"data":{"hello":"Hello world!"}}
 ```
 
-通过浏览器发送 GraphQL 也很简单。打开 http://localhost:4000，开启开发者控制台，粘贴：
+通过浏览器发送 GraphQL 也很简单。打开 http://localhost:4000 ，开启开发者控制台，粘贴：
 
 ```javascript
 var xhr = new XMLHttpRequest();


### PR DESCRIPTION
逗号与链接之间需要有空格，不然md工具会解析出错