### PR TITLE
补回一部分不应去掉的英文内容

### DIFF
--- a/site/blog/20160502-rest-api-graphql-wrapper.md
+++ b/site/blog/20160502-rest-api-graphql-wrapper.md
@@ -198,7 +198,7 @@ However, as we mentioned before, this architecture features some inherent perfor
 Take the next 10 minutes to watch me build a server side version of the GraphQL wrapper above using Node and Express.
 
 <iframe id="ytplayer" type="text/html" width="640" height="390"
-  src="http://www.youtube.com/embed/UBGzsb2UkeY?autoplay=0&origin=http://graphql.org&start=900"
+  src="https://www.youtube.com/embed/UBGzsb2UkeY?autoplay=0&origin=http://graphql.org&start=900"
   frameborder="0"></iframe>
 
 ## Bonus round: A truly Relay compliant schema

--- a/site/graphql-js/APIReference-Errors.md
+++ b/site/graphql-js/APIReference-Errors.md
@@ -14,7 +14,7 @@ import { GraphQLError } from 'graphql'; // ES6
 var { GraphQLError } = require('graphql'); // CommonJS
 ```
 
-## 概述
+## 概览
 
 <ul class="apiIndex">
   <li>

--- a/site/graphql-js/APIReference-Execution.md
+++ b/site/graphql-js/APIReference-Execution.md
@@ -14,7 +14,7 @@ import { execute } from 'graphql'; // ES6
 var { execute } = require('graphql'); // CommonJS
 ```
 
-## 概述
+## 概览
 
 <ul class="apiIndex">
   <li>
@@ -27,7 +27,7 @@ var { execute } = require('graphql'); // CommonJS
 
 ## 执行
 
-### 执行
+### execute
 
 ```js
 export function execute(

--- a/site/graphql-js/APIReference-GraphQL.md
+++ b/site/graphql-js/APIReference-GraphQL.md
@@ -13,7 +13,7 @@ import { graphql } from 'graphql'; // ES6
 var { graphql } = require('graphql'); // CommonJS
 ```
 
-## 概述
+## 概览
 
 **入口点**
 

--- a/site/graphql-js/APIReference-Language.md
+++ b/site/graphql-js/APIReference-Language.md
@@ -14,7 +14,7 @@ import { Source } from 'graphql'; // ES6
 var { Source } = require('graphql'); // CommonJS
 ```
 
-## 概述
+## 概览
 
 **Source**
 
@@ -33,7 +33,7 @@ var { Source } = require('graphql'); // CommonJS
   </li>
 </ul>
 
-**词法分析器**
+**词法分析器（Lexer）**
 
 <ul class="apiIndex">
   <li>
@@ -44,7 +44,7 @@ var { Source } = require('graphql'); // CommonJS
   </li>
 </ul>
 
-**解析器**
+**解析器（Parser）**
 
 <ul class="apiIndex">
   <li>
@@ -120,7 +120,7 @@ type SourceLocation = {
 
 接收一个 Source 对象和一个 UTF-8 编码的字符偏移量作为参数，返回一个 SourceLocation 对象，包含相关的行列位置信息。
 
-## 词法分析器
+## 词法分析器（Lexer）
 
 ### lex
 
@@ -141,7 +141,7 @@ export type Token = {
 
 词法分析器函数的参数是可选的，而且可被用于在 Source 里将词法分析器回退或者前进到某个新位置。
 
-## 解析器
+## 解析器（Parser）
 
 ### parse
 

--- a/site/graphql-js/APIReference-TypeSystem.md
+++ b/site/graphql-js/APIReference-TypeSystem.md
@@ -131,7 +131,7 @@ var { GraphQLSchema } = require('graphql'); // CommonJS
   </li>
 </ul>
 
-**标量（Scalar）类型**
+**标量类型（Scalars）**
 
 <ul class="apiIndex">
   <li>
@@ -595,7 +595,7 @@ function getNamedType(type: ?GraphQLType): ?GraphQLNamedType
 
 若该类型是非空类型或列表类型的包装结果，该函数会去掉包装，返回原先的类型。
 
-## Scalars
+## 标量类型（Scalars）
 
 ### GraphQLInt
 

--- a/site/graphql-js/APIReference-Utilities.md
+++ b/site/graphql-js/APIReference-Utilities.md
@@ -16,7 +16,7 @@ var { introspectionQuery } = require('graphql'); // CommonJS
 
 ## 概览
 
-**内省**
+**内省（Introspection）**
 
 <ul class="apiIndex">
   <li>
@@ -102,7 +102,7 @@ var { introspectionQuery } = require('graphql'); // CommonJS
   </li>
 </ul>
 
-## 内省
+## 内省（Introspection）
 
 ### introspectionQuery
 


### PR DESCRIPTION
今天正好用到，发现 graphql.js 的 API 中有一部分标题同时指代了该 API 所在的文件名，不应被翻译，因此把英文用括号补充到后边